### PR TITLE
Use dynamic server address

### DIFF
--- a/upservx/app/login/page.tsx
+++ b/upservx/app/login/page.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react"
 import { useRouter } from "next/navigation"
 import { useAuth } from "@/components/auth-provider"
+import { apiUrl } from "@/lib/api"
 
 export default function LoginPage() {
   const [username, setUsername] = useState("")
@@ -14,7 +15,7 @@ export default function LoginPage() {
     e.preventDefault()
     const token = btoa(`${username}:${password}`)
     try {
-      const res = await fetch("http://localhost:8000/", {
+      const res = await fetch(apiUrl("/"), {
         headers: { Authorization: `Basic ${token}` },
       })
       if (res.ok) {

--- a/upservx/components/containers.tsx
+++ b/upservx/components/containers.tsx
@@ -36,6 +36,7 @@ import {
   TableRow,
 } from "@/components/ui/table"
 import { TerminalEmulator } from "@/components/terminal-emulator"
+import { apiUrl } from "@/lib/api"
 
 export function Containers() {
   interface ContainerData {
@@ -78,7 +79,7 @@ export function Containers() {
 
   const loadMetrics = async () => {
     try {
-      const res = await fetch("http://localhost:8000/metrics")
+      const res = await fetch(apiUrl("/metrics"))
       if (res.ok) {
         const data = await res.json()
         if (data.cpu?.cores) setMaxCpu(data.cpu.cores)
@@ -98,7 +99,7 @@ export function Containers() {
     }
     const loadImages = async () => {
       try {
-        const res = await fetch(`http://localhost:8000/images?type=${type}`)
+        const res = await fetch(apiUrl(`/images?type=${type}`))
         if (res.ok) {
           const data = await res.json()
           setImages(data.images || [])
@@ -143,7 +144,7 @@ export function Containers() {
   useEffect(() => {
     const load = async () => {
       try {
-        const res = await fetch("http://localhost:8000/containers")
+        const res = await fetch(apiUrl("/containers"))
         if (res.ok) {
           const data = await res.json()
           setContainers(data)
@@ -179,7 +180,7 @@ export function Containers() {
     }
     const creating = name
     try {
-      const res = await fetch("http://localhost:8000/containers", {
+      const res = await fetch(apiUrl("/containers"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
@@ -187,7 +188,7 @@ export function Containers() {
       if (res.ok) {
         const c = await res.json()
         if (c.detail) {
-          const listRes = await fetch("http://localhost:8000/containers")
+          const listRes = await fetch(apiUrl("/containers"))
           if (listRes.ok) {
             const data = await listRes.json()
             setContainers(data)
@@ -205,7 +206,7 @@ export function Containers() {
 
   const handleStart = async (name: string) => {
     try {
-      const res = await fetch(`http://localhost:8000/containers/${name}/start`, {
+      const res = await fetch(apiUrl(`/containers/${name}/start`), {
         method: "POST",
       })
       if (res.ok) {
@@ -231,7 +232,7 @@ export function Containers() {
 
   const handleStop = async (name: string) => {
     try {
-      const res = await fetch(`http://localhost:8000/containers/${name}/stop`, {
+      const res = await fetch(apiUrl(`/containers/${name}/stop`), {
         method: "POST",
       })
       if (res.ok) {
@@ -257,7 +258,7 @@ export function Containers() {
 
   const handleDelete = async (name: string) => {
     try {
-      const res = await fetch(`http://localhost:8000/containers/${name}`, {
+      const res = await fetch(apiUrl(`/containers/${name}`), {
         method: "DELETE",
       })
       if (res.ok) {

--- a/upservx/components/image-management.tsx
+++ b/upservx/components/image-management.tsx
@@ -18,6 +18,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog"
 import { Disc, Download, Upload, Trash2, Plus, Container } from "lucide-react"
+import { apiUrl } from "@/lib/api"
 
 export function ImageManagement() {
   const [isoFiles, setIsoFiles] = useState<
@@ -61,7 +62,7 @@ export function ImageManagement() {
   useEffect(() => {
     const loadIsos = async () => {
       try {
-        const res = await fetch("http://localhost:8000/isos")
+        const res = await fetch(apiUrl("/isos"))
         if (res.ok) {
           const data = await res.json()
           setIsoFiles(data.isos || [])
@@ -76,7 +77,7 @@ export function ImageManagement() {
   useEffect(() => {
     const loadImages = async () => {
       try {
-        const res = await fetch("http://localhost:8000/images?type=docker&full=1")
+        const res = await fetch(apiUrl("/images?type=docker&full=1"))
         if (res.ok) {
           const data = await res.json()
           setContainerImages(data.images || [])
@@ -91,7 +92,7 @@ export function ImageManagement() {
   useEffect(() => {
     const loadLxcImages = async () => {
       try {
-        const res = await fetch("http://localhost:8000/images?type=lxc&full=1")
+        const res = await fetch(apiUrl("/images?type=lxc&full=1"))
         if (res.ok) {
           const data = await res.json()
           setLxcImages(data.images || [])
@@ -151,7 +152,7 @@ export function ImageManagement() {
     data.append("file", isoFile)
 
     const xhr = new XMLHttpRequest()
-    xhr.open("POST", "http://localhost:8000/isos")
+    xhr.open("POST", apiUrl("/isos"))
     xhr.upload.onprogress = (e) => {
       if (e.lengthComputable) {
         setUploadedBytes(e.loaded)
@@ -202,7 +203,7 @@ export function ImageManagement() {
     }, 200)
 
     try {
-      const res = await fetch("http://localhost:8000/isos/download", {
+      const res = await fetch(apiUrl("/isos/download"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ url: isoUrl, name: isoDownloadName || null }),
@@ -235,7 +236,7 @@ export function ImageManagement() {
 
   const handleDeleteIso = async (name: string) => {
     try {
-      const res = await fetch(`http://localhost:8000/isos/${name}`, { method: "DELETE" })
+      const res = await fetch(apiUrl(`/isos/${name}`), { method: "DELETE" })
       if (res.ok) {
         setIsoFiles((prev) => prev.filter((i) => i.name !== name))
       }
@@ -250,7 +251,7 @@ export function ImageManagement() {
   ) => {
     try {
       const res = await fetch(
-        `http://localhost:8000/images/${id}?type=docker`,
+        apiUrl(`/images/${id}?type=docker`),
         { method: "DELETE" },
       )
       if (res.ok) {
@@ -284,13 +285,13 @@ export function ImageManagement() {
     }, 200)
 
     try {
-      const res = await fetch("http://localhost:8000/images/pull", {
+      const res = await fetch(apiUrl("/images/pull"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ image: imageName, registry: registry || null }),
       })
       if (res.ok) {
-        const list = await fetch("http://localhost:8000/images?type=docker&full=1")
+        const list = await fetch(apiUrl("/images?type=docker&full=1"))
         if (list.ok) {
           const data = await list.json()
           setContainerImages(data.images || [])
@@ -320,7 +321,7 @@ export function ImageManagement() {
 
   const handleDeleteLxcImage = async (id: string, name: string) => {
     try {
-      const res = await fetch(`http://localhost:8000/images/${id}?type=lxc`, {
+      const res = await fetch(apiUrl(`/images/${id}?type=lxc`), {
         method: "DELETE",
       })
       if (res.ok) {
@@ -354,7 +355,7 @@ export function ImageManagement() {
     }, 200)
 
     try {
-      const res = await fetch("http://localhost:8000/images/pull", {
+      const res = await fetch(apiUrl("/images/pull"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -364,7 +365,7 @@ export function ImageManagement() {
         }),
       })
       if (res.ok) {
-        const list = await fetch("http://localhost:8000/images?type=lxc&full=1")
+        const list = await fetch(apiUrl("/images?type=lxc&full=1"))
         if (list.ok) {
           const data = await list.json()
           setLxcImages(data.images || [])
@@ -587,7 +588,7 @@ export function ImageManagement() {
                             className="h-8 w-8 bg-transparent"
                             asChild
                           >
-                            <a href={`http://localhost:8000/isos/${iso.name}/file`}>
+                            <a href={apiUrl(`/isos/${iso.name}/file`)}>
                               <Download className="h-3 w-3" />
                             </a>
                           </Button>

--- a/upservx/components/network-management.tsx
+++ b/upservx/components/network-management.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Network, Wifi, Settings } from "lucide-react"
+import { apiUrl } from "@/lib/api"
 
 interface NetworkInterface {
   name: string
@@ -39,7 +40,7 @@ export function NetworkManagement() {
   useEffect(() => {
     const loadInterfaces = async () => {
       try {
-        const res = await fetch("http://localhost:8000/network/interfaces")
+        const res = await fetch(apiUrl("/network/interfaces"))
         if (res.ok) {
           const data = await res.json()
           setNetworkInterfaces(data.interfaces || [])
@@ -52,7 +53,7 @@ export function NetworkManagement() {
 
     const loadSettings = async () => {
       try {
-        const res = await fetch("http://localhost:8000/network/settings")
+        const res = await fetch(apiUrl("/network/settings"))
         if (res.ok) {
           const data = await res.json()
           setNetworkSettings(data)
@@ -188,7 +189,7 @@ export function NetworkManagement() {
                 <Button
                   onClick={async () => {
                     try {
-                      const res = await fetch("http://localhost:8000/network/settings", {
+                      const res = await fetch(apiUrl("/network/settings"), {
                         method: "POST",
                         headers: { "Content-Type": "application/json" },
                         body: JSON.stringify(networkSettings),

--- a/upservx/components/settings.tsx
+++ b/upservx/components/settings.tsx
@@ -5,6 +5,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { apiUrl } from "@/lib/api"
 
 export function Settings() {
   interface SettingsData {
@@ -26,7 +27,7 @@ export function Settings() {
 
   const loadSettings = async () => {
     try {
-      const res = await fetch("http://localhost:8000/settings")
+      const res = await fetch(apiUrl("/settings"))
       if (res.ok) {
         const data = await res.json()
         setSettings({
@@ -54,7 +55,7 @@ export function Settings() {
 
   const handleSave = async () => {
     try {
-      const res = await fetch("http://localhost:8000/settings", {
+      const res = await fetch(apiUrl("/settings"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(settings),

--- a/upservx/components/sidebar.tsx
+++ b/upservx/components/sidebar.tsx
@@ -14,6 +14,7 @@ import {
   Disc,
 } from "lucide-react"
 import { useEffect, useState } from "react"
+import { apiUrl } from "@/lib/api"
 
 interface SidebarProps {
   activeSection: string
@@ -26,7 +27,7 @@ export function Sidebar({ activeSection, onSectionChange }: SidebarProps) {
   useEffect(() => {
     const loadHostname = async () => {
       try {
-        const res = await fetch("http://localhost:8000/settings")
+        const res = await fetch(apiUrl("/settings"))
         if (res.ok) {
           const data = await res.json()
           setHostname(data.hostname)

--- a/upservx/components/storage-management.tsx
+++ b/upservx/components/storage-management.tsx
@@ -31,12 +31,13 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog"
 import { HardDrive, Usb, MemoryStickIcon as SdCard, Settings, AlertTriangle } from "lucide-react"
+import { apiUrl } from "@/lib/api"
 
 export function StorageManagement() {
   const [drives, setDrives] = useState<Drive[]>([])
   const loadDrives = async () => {
     try {
-      const res = await fetch("http://localhost:8000/drives")
+      const res = await fetch(apiUrl("/drives"))
       if (res.ok) {
         const data = await res.json()
         setDrives(data.drives || [])
@@ -89,7 +90,7 @@ export function StorageManagement() {
   const handleFormat = async () => {
     if (!activeDrive) return
     try {
-      const res = await fetch("http://localhost:8000/drives/format", {
+      const res = await fetch(apiUrl("/drives/format"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -115,7 +116,7 @@ export function StorageManagement() {
   const handleMount = async () => {
     if (!activeDrive) return
     try {
-      await fetch("http://localhost:8000/drives/mount", {
+      await fetch(apiUrl("/drives/mount"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ device: activeDrive.device, mountpoint: mountPath }),

--- a/upservx/components/system-overview.tsx
+++ b/upservx/components/system-overview.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/table"
 import { Cpu, HardDrive, MemoryStick, Activity } from "lucide-react"
 import { useEffect, useState } from "react"
+import { apiUrl } from "@/lib/api"
 
 export function SystemOverview() {
   const [systemStats, setSystemStats] = useState({
@@ -49,7 +50,7 @@ export function SystemOverview() {
   useEffect(() => {
     const fetchMetrics = async () => {
       try {
-        const res = await fetch("http://localhost:8000/metrics")
+        const res = await fetch(apiUrl("/metrics"))
         if (res.ok) {
           const data = await res.json()
           setSystemStats(data)
@@ -84,7 +85,7 @@ export function SystemOverview() {
   useEffect(() => {
     const loadDrives = async () => {
       try {
-        const res = await fetch("http://localhost:8000/drives")
+        const res = await fetch(apiUrl("/drives"))
         if (res.ok) {
           const data = await res.json()
           setDrives(data.drives || [])

--- a/upservx/components/terminal-emulator.tsx
+++ b/upservx/components/terminal-emulator.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { X } from "lucide-react"
+import { wsUrl } from "@/lib/api"
 
 interface TerminalEmulatorProps {
   containerName: string
@@ -21,7 +22,7 @@ export function TerminalEmulator({ containerName, onClose }: TerminalEmulatorPro
 
   useEffect(() => {
     setClosed(false)
-    const ws = new WebSocket(`ws://localhost:8000/containers/${containerName}/terminal`)
+    const ws = new WebSocket(wsUrl(`/containers/${containerName}/terminal`))
     wsRef.current = ws
     ws.onmessage = (ev) => {
       setHistory((prev) => [...prev, ev.data])

--- a/upservx/components/user-management.tsx
+++ b/upservx/components/user-management.tsx
@@ -24,6 +24,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { User, Users, Plus, Settings, Key } from "lucide-react"
+import { apiUrl } from "@/lib/api"
 
 interface SysUser {
   username: string
@@ -69,7 +70,7 @@ export function UserManagement() {
         limit: size.toString(),
         offset: ((page - 1) * size).toString(),
       })
-      const res = await fetch(`http://localhost:8000/users?${params}`)
+      const res = await fetch(apiUrl(`/users?${params}`))
       if (res.ok) {
         const data = await res.json()
         setUsers(data.users || [])
@@ -86,7 +87,7 @@ export function UserManagement() {
         limit: size.toString(),
         offset: ((page - 1) * size).toString(),
       })
-      const res = await fetch(`http://localhost:8000/groups?${params}`)
+      const res = await fetch(apiUrl(`/groups?${params}`))
       if (res.ok) {
         const data = await res.json()
         setGroups(data.groups || [])
@@ -99,7 +100,7 @@ export function UserManagement() {
 
   const loadAllGroups = async () => {
     try {
-      const res = await fetch("http://localhost:8000/groups?limit=1000")
+      const res = await fetch(apiUrl("/groups?limit=1000"))
       if (res.ok) {
         const data = await res.json()
         setAllGroups(data.groups || [])
@@ -111,7 +112,7 @@ export function UserManagement() {
 
   const loadAllUsers = async () => {
     try {
-      const res = await fetch("http://localhost:8000/users?limit=1000")
+      const res = await fetch(apiUrl("/users?limit=1000"))
       if (res.ok) {
         const data = await res.json()
         setAllUsers(data.users || [])
@@ -123,7 +124,7 @@ export function UserManagement() {
 
   const loadUserKeys = async (user: SysUser) => {
     try {
-      const res = await fetch(`http://localhost:8000/users/${user.username}/keys`)
+      const res = await fetch(apiUrl(`/users/${user.username}/keys`))
       if (res.ok) {
         const data = await res.json()
         setUserKeys(data.keys || [])
@@ -166,7 +167,7 @@ export function UserManagement() {
 
   const handleCreateUser = async () => {
     try {
-      const res = await fetch("http://localhost:8000/users", {
+      const res = await fetch(apiUrl("/users"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -203,7 +204,7 @@ export function UserManagement() {
 
   const handleCreateGroup = async () => {
     try {
-      const res = await fetch("http://localhost:8000/groups", {
+      const res = await fetch(apiUrl("/groups"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -238,7 +239,7 @@ export function UserManagement() {
   const handleSaveKeys = async () => {
     if (!keyUser) return
     try {
-      const res = await fetch(`http://localhost:8000/users/${keyUser.username}/keys`, {
+      const res = await fetch(apiUrl(`/users/${keyUser.username}/keys`), {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ keys: userKeys.filter((k) => k.trim() !== "") }),
@@ -429,7 +430,7 @@ export function UserManagement() {
                 </Button>
                 <Button
                   onClick={async () => {
-                    const res = await fetch(`http://localhost:8000/users/${editUser.username}`, {
+                    const res = await fetch(apiUrl(`/users/${editUser.username}`), {
                       method: "PUT",
                       headers: { "Content-Type": "application/json" },
                       body: JSON.stringify({ shell: editUser.shell, groups: editUser.groups.filter(Boolean) }),
@@ -753,7 +754,7 @@ export function UserManagement() {
                         </Button>
                         <Button
                           onClick={async () => {
-                            const res = await fetch(`http://localhost:8000/groups/${editGroup.name}`, {
+                            const res = await fetch(apiUrl(`/groups/${editGroup.name}`), {
                               method: "PUT",
                               headers: { "Content-Type": "application/json" },
                               body: JSON.stringify({ members: editGroup.members.filter(Boolean) }),

--- a/upservx/lib/api.ts
+++ b/upservx/lib/api.ts
@@ -1,0 +1,16 @@
+export function apiUrl(path: string): string {
+  if (typeof window !== "undefined") {
+    const { protocol, hostname } = window.location
+    const scheme = protocol.startsWith("http") ? protocol : "http:"
+    return `${scheme}//${hostname}:8000${path}`
+  }
+  return `http://localhost:8000${path}`
+}
+
+export function wsUrl(path: string): string {
+  if (typeof window !== "undefined") {
+    const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:"
+    return `${wsProtocol}//${window.location.hostname}:8000${path}`
+  }
+  return `ws://localhost:8000${path}`
+}


### PR DESCRIPTION
## Summary
- add api helper for building HTTP and WS URLs
- use api helper everywhere instead of hardcoded localhost

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68741529fe7483288108f7499fe374c4