### PR TITLE
Show architecture in dashboard

### DIFF
--- a/upservx-service/main.py
+++ b/upservx-service/main.py
@@ -943,6 +943,7 @@ def collect_metrics() -> dict:
         "gpu": get_gpu_model(),
         "uptime": format_uptime(uptime_seconds),
         "kernel": platform.release(),
+        "architecture": platform.machine(),
         "services": services,
     }
 

--- a/upservx/components/system-overview.tsx
+++ b/upservx/components/system-overview.tsx
@@ -22,6 +22,7 @@ export function SystemOverview() {
     uptime: "",
     kernel: "",
     gpu: "",
+    architecture: "",
     services: [] as { name: string; status: string; port: number | null }[],
   })
 
@@ -199,7 +200,7 @@ export function SystemOverview() {
             </div>
             <div className="flex justify-between">
               <span className="text-sm text-muted-foreground">Architektur:</span>
-              <span className="text-sm font-medium">x86_64</span>
+              <span className="text-sm font-medium">{systemStats.architecture}</span>
             </div>
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- include `platform.machine()` in `/metrics` response
- display architecture data in System Overview

## Testing
- `python3 -m py_compile main.py`
- `npm install`
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68741c326a988328be139b5c74460a92