### PR TITLE
Add systemd services management

### DIFF
--- a/upservx/components/dashboard.tsx
+++ b/upservx/components/dashboard.tsx
@@ -6,6 +6,7 @@ import { Header } from "@/components/header"
 import { SystemOverview } from "@/components/system-overview"
 import { VirtualMachines } from "@/components/virtual-machines"
 import { Containers } from "@/components/containers"
+import { Services } from "@/components/services"
 import { Settings } from "@/components/settings"
 import { NetworkManagement } from "@/components/network-management"
 import { StorageManagement } from "@/components/storage-management"
@@ -24,6 +25,8 @@ export function Dashboard() {
         return <VirtualMachines />
       case "containers":
         return <Containers />
+      case "services":
+        return <Services />
       case "network":
         return <NetworkManagement />
       case "storage":

--- a/upservx/components/services.tsx
+++ b/upservx/components/services.tsx
@@ -1,135 +1,87 @@
 "use client"
 
-import { useState } from "react"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { useState, useEffect } from "react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Switch } from "@/components/ui/switch"
-import { Play, Square, Settings, RefreshCw } from "lucide-react"
+import { Play, Square } from "lucide-react"
+import { apiUrl } from "@/lib/api"
+
+interface ServiceInfo {
+  name: string
+  status: string
+  enabled: boolean
+}
 
 export function Services() {
-  const [services, setServices] = useState([
-    {
-      id: 1,
-      name: "Apache HTTP Server",
-      status: "running",
-      autostart: true,
-      port: 80,
-      description: "Web Server für statische Inhalte",
-      uptime: "5 Tage, 12 Stunden",
-    },
-    {
-      id: 2,
-      name: "MySQL Database",
-      status: "running",
-      autostart: true,
-      port: 3306,
-      description: "Relationale Datenbank",
-      uptime: "15 Tage, 7 Stunden",
-    },
-    {
-      id: 3,
-      name: "Redis Cache",
-      status: "stopped",
-      autostart: false,
-      port: 6379,
-      description: "In-Memory Datenbank für Caching",
-      uptime: "0 Minuten",
-    },
-    {
-      id: 4,
-      name: "Nginx Proxy",
-      status: "running",
-      autostart: true,
-      port: 443,
-      description: "Reverse Proxy und Load Balancer",
-      uptime: "2 Tage, 18 Stunden",
-    },
-    {
-      id: 5,
-      name: "Docker Daemon",
-      status: "running",
-      autostart: true,
-      port: 2376,
-      description: "Container Runtime",
-      uptime: "15 Tage, 7 Stunden",
-    },
-  ])
+  const [services, setServices] = useState<ServiceInfo[]>([])
 
-  const toggleService = (id: number) => {
-    setServices(
-      services.map((service) =>
-        service.id === id ? { ...service, status: service.status === "running" ? "stopped" : "running" } : service,
-      ),
-    )
+  const loadServices = async () => {
+    try {
+      const res = await fetch(apiUrl("/services"))
+      if (res.ok) {
+        const data = await res.json()
+        setServices(data.services || [])
+      }
+    } catch (e) {
+      console.error(e)
+    }
   }
 
-  const toggleAutostart = (id: number) => {
-    setServices(
-      services.map((service) => (service.id === id ? { ...service, autostart: !service.autostart } : service)),
-    )
+  useEffect(() => {
+    loadServices()
+  }, [])
+
+  const toggleService = async (name: string, running: boolean) => {
+    try {
+      const res = await fetch(apiUrl(`/services/${name}/${running ? "stop" : "start"}`), { method: "POST" })
+      if (res.ok) {
+        setServices((prev) => prev.map((s) => (s.name === name ? { ...s, status: running ? "stopped" : "running" } : s)))
+      }
+    } catch (e) {
+      console.error(e)
+    }
   }
 
-  const getStatusColor = (status: string) => {
-    return status === "running" ? "default" : "secondary"
+  const toggleEnabled = async (name: string, enabled: boolean) => {
+    try {
+      const res = await fetch(apiUrl(`/services/${name}/${enabled ? "disable" : "enable"}`), { method: "POST" })
+      if (res.ok) {
+        setServices((prev) => prev.map((s) => (s.name === name ? { ...s, enabled: !enabled } : s)))
+      }
+    } catch (e) {
+      console.error(e)
+    }
   }
+
+  const badgeVariant = (status: string) => (status === "running" ? "default" : status === "not found" ? "destructive" : "secondary")
 
   return (
     <div className="space-y-6">
       <div>
         <h2 className="text-3xl font-bold tracking-tight">Services</h2>
-        <p className="text-muted-foreground">Verwalten Sie Systemdienste und Anwendungen</p>
       </div>
-
       <div className="grid gap-4">
         {services.map((service) => (
-          <Card key={service.id}>
+          <Card key={service.name}>
             <CardHeader>
               <div className="flex items-center justify-between">
-                <div>
-                  <CardTitle className="flex items-center gap-2">
-                    {service.name}
-                    <Badge variant={getStatusColor(service.status)}>
-                      {service.status === "running" ? "Läuft" : "Gestoppt"}
-                    </Badge>
-                  </CardTitle>
-                  <CardDescription>{service.description}</CardDescription>
-                </div>
+                <CardTitle className="flex items-center gap-2">
+                  {service.name}
+                  <Badge variant={badgeVariant(service.status)}>
+                    {service.status === "running" ? "Running" : service.status === "not found" ? "Not found" : "Stopped"}
+                  </Badge>
+                </CardTitle>
                 <div className="flex items-center space-x-2">
-                  <Button variant="outline" size="icon">
-                    <Settings className="h-4 w-4" />
-                  </Button>
-                  <Button variant="outline" size="icon">
-                    <RefreshCw className="h-4 w-4" />
-                  </Button>
-                  <Button variant="outline" size="icon" onClick={() => toggleService(service.id)}>
+                  <Switch checked={service.enabled} onCheckedChange={() => toggleEnabled(service.name, service.enabled)} />
+                  <Button variant="outline" size="icon" onClick={() => toggleService(service.name, service.status === "running")}>
                     {service.status === "running" ? <Square className="h-4 w-4" /> : <Play className="h-4 w-4" />}
                   </Button>
                 </div>
               </div>
             </CardHeader>
-            <CardContent>
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
-                <div>
-                  <span className="text-muted-foreground">Port:</span>
-                  <div className="font-medium">{service.port}</div>
-                </div>
-                <div>
-                  <span className="text-muted-foreground">Uptime:</span>
-                  <div className="font-medium">{service.uptime}</div>
-                </div>
-                <div className="flex items-center space-x-2">
-                  <span className="text-muted-foreground">Autostart:</span>
-                  <Switch checked={service.autostart} onCheckedChange={() => toggleAutostart(service.id)} />
-                </div>
-                <div>
-                  <span className="text-muted-foreground">PID:</span>
-                  <div className="font-medium">
-                    {service.status === "running" ? Math.floor(Math.random() * 10000) + 1000 : "-"}
-                  </div>
-                </div>
-              </div>
-            </CardContent>
+            <CardContent />
           </Card>
         ))}
       </div>

--- a/upservx/components/sidebar.tsx
+++ b/upservx/components/sidebar.tsx
@@ -43,6 +43,7 @@ export function Sidebar({ activeSection, onSectionChange }: SidebarProps) {
     { id: "dashboard", label: "Dashboard", icon: BarChart3 },
     { id: "vms", label: "Virtual Machines", icon: Server },
     { id: "containers", label: "Container", icon: Container },
+    { id: "services", label: "Services", icon: Settings },
     { id: "images", label: "Images & ISOs", icon: Disc },
     { id: "network", label: "Network", icon: Network },
     { id: "storage", label: "Storage", icon: HardDrive },


### PR DESCRIPTION
## Summary
- add list_systemd_services helper and API endpoints for start/stop/enable/disable
- fetch systemd services in Services component
- register Services module in sidebar and dashboard

## Testing
- `pytest -q`
- `npm run lint --silent` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882ad5b5d908328a530a7ca8e500787