### PR TITLE
Add empty-state rows for VM and image tables

### DIFF
--- a/upservx/components/image-management.tsx
+++ b/upservx/components/image-management.tsx
@@ -558,7 +558,7 @@ export function ImageManagement() {
                 </TableHeader>
                 <TableBody>
                   {isoFiles.length === 0 ? (
-                    <TableRow className="border-t border-border">
+                    <TableRow>
                       <TableCell colSpan={8} className="text-center">
                         No isos found
                       </TableCell>
@@ -693,7 +693,7 @@ export function ImageManagement() {
                 </TableHeader>
                 <TableBody>
                   {lxcImages.length === 0 ? (
-                    <TableRow className="border-t border-border">
+                    <TableRow>
                       <TableCell colSpan={7} className="text-center">
                         No images found
                       </TableCell>
@@ -812,7 +812,7 @@ export function ImageManagement() {
                 </TableHeader>
                 <TableBody>
                   {containerImages.length === 0 ? (
-                    <TableRow className="border-t border-border">
+                    <TableRow>
                       <TableCell colSpan={7} className="text-center">
                         No images found
                       </TableCell>

--- a/upservx/components/image-management.tsx
+++ b/upservx/components/image-management.tsx
@@ -558,7 +558,7 @@ export function ImageManagement() {
                 </TableHeader>
                 <TableBody>
                   {isoFiles.length === 0 ? (
-                    <TableRow>
+                    <TableRow className="border-t border-border">
                       <TableCell colSpan={8} className="text-center">
                         No isos found
                       </TableCell>
@@ -693,7 +693,7 @@ export function ImageManagement() {
                 </TableHeader>
                 <TableBody>
                   {lxcImages.length === 0 ? (
-                    <TableRow>
+                    <TableRow className="border-t border-border">
                       <TableCell colSpan={7} className="text-center">
                         No images found
                       </TableCell>
@@ -812,7 +812,7 @@ export function ImageManagement() {
                 </TableHeader>
                 <TableBody>
                   {containerImages.length === 0 ? (
-                    <TableRow>
+                    <TableRow className="border-t border-border">
                       <TableCell colSpan={7} className="text-center">
                         No images found
                       </TableCell>

--- a/upservx/components/image-management.tsx
+++ b/upservx/components/image-management.tsx
@@ -557,54 +557,62 @@ export function ImageManagement() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {isoFiles.map((iso) => (
-                    <TableRow key={iso.id}>
-                      <TableCell>
-                        <div className="flex items-center gap-2">
-                          <Disc className="h-4 w-4" />
-                          <div>
-                            <div className="font-medium">{iso.name}</div>
-                            <div className="text-xs text-muted-foreground">{iso.path}</div>
-                          </div>
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <Badge variant="outline">{iso.type}</Badge>
-                      </TableCell>
-                      <TableCell>{iso.version}</TableCell>
-                      <TableCell>{iso.architecture}</TableCell>
-                      <TableCell>{formatSize(iso.size)}</TableCell>
-                      <TableCell>{iso.created}</TableCell>
-                      <TableCell>
-                        <Badge variant={iso.used ? "default" : "secondary"}>
-                          {iso.used ? "In use" : "Available"}
-                        </Badge>
-                      </TableCell>
-                      <TableCell>
-                        <div className="flex gap-1">
-                          <Button
-                            variant="outline"
-                            size="icon"
-                            className="h-8 w-8 bg-transparent"
-                            asChild
-                          >
-                            <a href={apiUrl(`/isos/${iso.name}/file`)}>
-                              <Download className="h-3 w-3" />
-                            </a>
-                          </Button>
-                          <Button
-                            variant="outline"
-                            size="icon"
-                            className="h-8 w-8 bg-transparent"
-                            disabled={iso.used}
-                            onClick={() => handleDeleteIso(iso.name)}
-                          >
-                            <Trash2 className="h-3 w-3" />
-                          </Button>
-                        </div>
+                  {isoFiles.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={8} className="text-center">
+                        No isos found
                       </TableCell>
                     </TableRow>
-                  ))}
+                  ) : (
+                    isoFiles.map((iso) => (
+                      <TableRow key={iso.id}>
+                        <TableCell>
+                          <div className="flex items-center gap-2">
+                            <Disc className="h-4 w-4" />
+                            <div>
+                              <div className="font-medium">{iso.name}</div>
+                              <div className="text-xs text-muted-foreground">{iso.path}</div>
+                            </div>
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant="outline">{iso.type}</Badge>
+                        </TableCell>
+                        <TableCell>{iso.version}</TableCell>
+                        <TableCell>{iso.architecture}</TableCell>
+                        <TableCell>{formatSize(iso.size)}</TableCell>
+                        <TableCell>{iso.created}</TableCell>
+                        <TableCell>
+                          <Badge variant={iso.used ? "default" : "secondary"}>
+                            {iso.used ? "In use" : "Available"}
+                          </Badge>
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex gap-1">
+                            <Button
+                              variant="outline"
+                              size="icon"
+                              className="h-8 w-8 bg-transparent"
+                              asChild
+                            >
+                              <a href={apiUrl(`/isos/${iso.name}/file`)}>
+                                <Download className="h-3 w-3" />
+                              </a>
+                            </Button>
+                            <Button
+                              variant="outline"
+                              size="icon"
+                              className="h-8 w-8 bg-transparent"
+                              disabled={iso.used}
+                              onClick={() => handleDeleteIso(iso.name)}
+                            >
+                              <Trash2 className="h-3 w-3" />
+                            </Button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))
+                  )}
                 </TableBody>
               </Table>
             </CardContent>
@@ -684,38 +692,46 @@ export function ImageManagement() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {lxcImages.map((image) => (
-                    <TableRow key={image.id}>
-                      <TableCell>
-                        <div className="flex items-center gap-2">
-                          <Container className="h-4 w-4" />
-                          <span className="font-medium">{image.repository}</span>
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <Badge variant="outline">{image.tag}</Badge>
-                      </TableCell>
-                      <TableCell className="font-mono text-xs">{image.imageId}</TableCell>
-                      <TableCell>{formatSize(image.size / 1000)}</TableCell>
-                      <TableCell>{image.created}</TableCell>
-                      <TableCell>{formatPulls(image.pulls)}</TableCell>
-                      <TableCell>
-                        <div className="flex gap-1">
-                          <Button variant="outline" size="icon" className="h-8 w-8 bg-transparent">
-                            <Download className="h-3 w-3" />
-                          </Button>
-                          <Button
-                            variant="outline"
-                            size="icon"
-                            className="h-8 w-8 bg-transparent"
-                            onClick={() => handleDeleteLxcImage(image.imageId, `${image.repository}:${image.tag}`)}
-                          >
-                            <Trash2 className="h-3 w-3" />
-                          </Button>
-                        </div>
+                  {lxcImages.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={7} className="text-center">
+                        No images found
                       </TableCell>
                     </TableRow>
-                  ))}
+                  ) : (
+                    lxcImages.map((image) => (
+                      <TableRow key={image.id}>
+                        <TableCell>
+                          <div className="flex items-center gap-2">
+                            <Container className="h-4 w-4" />
+                            <span className="font-medium">{image.repository}</span>
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant="outline">{image.tag}</Badge>
+                        </TableCell>
+                        <TableCell className="font-mono text-xs">{image.imageId}</TableCell>
+                        <TableCell>{formatSize(image.size / 1000)}</TableCell>
+                        <TableCell>{image.created}</TableCell>
+                        <TableCell>{formatPulls(image.pulls)}</TableCell>
+                        <TableCell>
+                          <div className="flex gap-1">
+                            <Button variant="outline" size="icon" className="h-8 w-8 bg-transparent">
+                              <Download className="h-3 w-3" />
+                            </Button>
+                            <Button
+                              variant="outline"
+                              size="icon"
+                              className="h-8 w-8 bg-transparent"
+                              onClick={() => handleDeleteLxcImage(image.imageId, `${image.repository}:${image.tag}`)}
+                            >
+                              <Trash2 className="h-3 w-3" />
+                            </Button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))
+                  )}
                 </TableBody>
               </Table>
             </CardContent>
@@ -795,38 +811,46 @@ export function ImageManagement() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {containerImages.map((image) => (
-                    <TableRow key={image.id}>
-                      <TableCell>
-                        <div className="flex items-center gap-2">
-                          <Container className="h-4 w-4" />
-                          <span className="font-medium">{image.repository}</span>
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <Badge variant="outline">{image.tag}</Badge>
-                      </TableCell>
-                      <TableCell className="font-mono text-xs">{image.imageId}</TableCell>
-                      <TableCell>{formatSize(image.size / 1000)}</TableCell>
-                      <TableCell>{image.created}</TableCell>
-                      <TableCell>{formatPulls(image.pulls)}</TableCell>
-                      <TableCell>
-                        <div className="flex gap-1">
-                          <Button variant="outline" size="icon" className="h-8 w-8 bg-transparent">
-                            <Download className="h-3 w-3" />
-                          </Button>
-                          <Button
-                            variant="outline"
-                            size="icon"
-                            className="h-8 w-8 bg-transparent"
-                            onClick={() => handleDeleteImage(image.imageId, `${image.repository}:${image.tag}`)}
-                          >
-                            <Trash2 className="h-3 w-3" />
-                          </Button>
-                        </div>
+                  {containerImages.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={7} className="text-center">
+                        No images found
                       </TableCell>
                     </TableRow>
-                  ))}
+                  ) : (
+                    containerImages.map((image) => (
+                      <TableRow key={image.id}>
+                        <TableCell>
+                          <div className="flex items-center gap-2">
+                            <Container className="h-4 w-4" />
+                            <span className="font-medium">{image.repository}</span>
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant="outline">{image.tag}</Badge>
+                        </TableCell>
+                        <TableCell className="font-mono text-xs">{image.imageId}</TableCell>
+                        <TableCell>{formatSize(image.size / 1000)}</TableCell>
+                        <TableCell>{image.created}</TableCell>
+                        <TableCell>{formatPulls(image.pulls)}</TableCell>
+                        <TableCell>
+                          <div className="flex gap-1">
+                            <Button variant="outline" size="icon" className="h-8 w-8 bg-transparent">
+                              <Download className="h-3 w-3" />
+                            </Button>
+                            <Button
+                              variant="outline"
+                              size="icon"
+                              className="h-8 w-8 bg-transparent"
+                              onClick={() => handleDeleteImage(image.imageId, `${image.repository}:${image.tag}`)}
+                            >
+                              <Trash2 className="h-3 w-3" />
+                            </Button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))
+                  )}
                 </TableBody>
               </Table>
             </CardContent>

--- a/upservx/components/sidebar.tsx
+++ b/upservx/components/sidebar.tsx
@@ -44,13 +44,13 @@ export function Sidebar({ activeSection, onSectionChange }: SidebarProps) {
     { id: "dashboard", label: "Dashboard", icon: BarChart3 },
     { id: "vms", label: "Virtual Machines", icon: Server },
     { id: "containers", label: "Container", icon: Container },
-    { id: "services", label: "Services", icon: Settings },
     { id: "images", label: "Images & ISOs", icon: Disc },
     { id: "network", label: "Network", icon: Network },
     { id: "storage", label: "Storage", icon: HardDrive },
     { id: "users", label: "Users", icon: Users },
     { id: "backup", label: "Backup", icon: Shield },
     { id: "logs", label: "Logs", icon: FileText },
+    { id: "services", label: "Services", icon: Settings },
     { id: "settings", label: "Settings", icon: Settings },
   ]
 

--- a/upservx/components/virtual-machines.tsx
+++ b/upservx/components/virtual-machines.tsx
@@ -10,6 +10,14 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, DialogDescription } from "@/components/ui/dialog"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { LayoutGrid, List as ListIcon, Play, Square, Plus, Trash2, Pencil } from "lucide-react"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
 import { apiUrl } from "@/lib/api"
 
 export function VirtualMachines() {
@@ -167,7 +175,7 @@ export function VirtualMachines() {
       )}
       <div className="flex justify-between items-center">
         <div>
-          <h2 className="text-3xl font-bold tracking-tight">Virtual Machines</h2>
+          <h2 className="text-3xl tracking-tight">Virtual Machines</h2>
           <p className="text-muted-foreground">Manage your virtual machines</p>
         </div>
         <div className="flex items-center gap-2">
@@ -291,35 +299,35 @@ export function VirtualMachines() {
       ) : (
         <Card>
           <CardContent className="py-0 pl-6 pr-0">
-            <table className="w-full">
-              <thead>
-                <tr className="text-left">
-                  <th>Name</th>
-                  <th>Status</th>
-                  <th>ISO</th>
-                  <th>CPU</th>
-                  <th>Memory</th>
-                  <th>Created</th>
-                  <th>Actions</th>
-                </tr>
-              </thead>
-              <tbody>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="font-normal">Name</TableHead>
+                  <TableHead className="font-normal">Status</TableHead>
+                  <TableHead className="font-normal">ISO</TableHead>
+                  <TableHead className="font-normal">CPU</TableHead>
+                  <TableHead className="font-normal">Memory</TableHead>
+                  <TableHead className="font-normal">Created</TableHead>
+                  <TableHead className="font-normal">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
                 {vms.length === 0 ? (
-                  <tr className="border-t border-border">
-                    <td colSpan={7} className="text-center">
+                  <TableRow>
+                    <TableCell colSpan={7} className="text-center">
                       No virtual machines found
-                    </td>
-                  </tr>
+                    </TableCell>
+                  </TableRow>
                 ) : (
                   vms.map((vm) => (
-                    <tr key={vm.id} className="border-t border-border">
-                      <td className="py-2">{vm.name}</td>
-                      <td>{vm.status}</td>
-                      <td className="text-sm">{vm.iso}</td>
-                      <td>{vm.cpu}</td>
-                      <td>{vm.memory}</td>
-                      <td className="text-sm">{vm.created}</td>
-                      <td>
+                    <TableRow key={vm.id}>
+                      <TableCell className="py-2">{vm.name}</TableCell>
+                      <TableCell>{vm.status}</TableCell>
+                      <TableCell className="text-sm">{vm.iso}</TableCell>
+                      <TableCell>{vm.cpu}</TableCell>
+                      <TableCell>{vm.memory}</TableCell>
+                      <TableCell className="text-sm">{vm.created}</TableCell>
+                      <TableCell>
                         <div className="flex gap-1">
                           {vm.status.includes("running") ? (
                             <Button variant="destructive" size="icon" onClick={() => handleStop(vm.name)}>
@@ -337,12 +345,12 @@ export function VirtualMachines() {
                             <Trash2 className="h-4 w-4" />
                           </Button>
                         </div>
-                      </td>
-                    </tr>
+                      </TableCell>
+                    </TableRow>
                   ))
                 )}
-              </tbody>
-            </table>
+              </TableBody>
+            </Table>
           </CardContent>
         </Card>
       )}

--- a/upservx/components/virtual-machines.tsx
+++ b/upservx/components/virtual-machines.tsx
@@ -175,7 +175,7 @@ export function VirtualMachines() {
       )}
       <div className="flex justify-between items-center">
         <div>
-          <h2 className="text-3xl tracking-tight">Virtual Machines</h2>
+          <h2 className="text-3xl font-bold tracking-tight">Virtual Machines</h2>
           <p className="text-muted-foreground">Manage your virtual machines</p>
         </div>
         <div className="flex items-center gap-2">

--- a/upservx/components/virtual-machines.tsx
+++ b/upservx/components/virtual-machines.tsx
@@ -305,7 +305,7 @@ export function VirtualMachines() {
               </thead>
               <tbody>
                 {vms.length === 0 ? (
-                  <tr>
+                  <tr className="border-t border-border">
                     <td colSpan={7} className="text-center">
                       No virtual machines found
                     </td>

--- a/upservx/components/virtual-machines.tsx
+++ b/upservx/components/virtual-machines.tsx
@@ -304,35 +304,43 @@ export function VirtualMachines() {
                 </tr>
               </thead>
               <tbody>
-                {vms.map(vm => (
-                  <tr key={vm.id} className="border-t border-border">
-                    <td className="py-2">{vm.name}</td>
-                    <td>{vm.status}</td>
-                    <td className="text-sm">{vm.iso}</td>
-                    <td>{vm.cpu}</td>
-                    <td>{vm.memory}</td>
-                    <td className="text-sm">{vm.created}</td>
-                    <td>
-                      <div className="flex gap-1">
-                        {vm.status.includes("running") ? (
-                          <Button variant="destructive" size="icon" onClick={() => handleStop(vm.name)}>
-                            <Square className="h-4 w-4" />
-                          </Button>
-                        ) : (
-                          <Button className="bg-green-600 text-white hover:bg-green-700" size="icon" onClick={() => handleStart(vm.name)}>
-                            <Play className="h-4 w-4" />
-                          </Button>
-                        )}
-                        <Button variant="outline" size="icon" onClick={() => openEdit(vm)}>
-                          <Pencil className="h-4 w-4" />
-                        </Button>
-                        <Button variant="destructive" size="icon" onClick={() => handleDelete(vm.name)}>
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
-                      </div>
+                {vms.length === 0 ? (
+                  <tr>
+                    <td colSpan={7} className="text-center">
+                      No virtual machines found
                     </td>
                   </tr>
-                ))}
+                ) : (
+                  vms.map((vm) => (
+                    <tr key={vm.id} className="border-t border-border">
+                      <td className="py-2">{vm.name}</td>
+                      <td>{vm.status}</td>
+                      <td className="text-sm">{vm.iso}</td>
+                      <td>{vm.cpu}</td>
+                      <td>{vm.memory}</td>
+                      <td className="text-sm">{vm.created}</td>
+                      <td>
+                        <div className="flex gap-1">
+                          {vm.status.includes("running") ? (
+                            <Button variant="destructive" size="icon" onClick={() => handleStop(vm.name)}>
+                              <Square className="h-4 w-4" />
+                            </Button>
+                          ) : (
+                            <Button className="bg-green-600 text-white hover:bg-green-700" size="icon" onClick={() => handleStart(vm.name)}>
+                              <Play className="h-4 w-4" />
+                            </Button>
+                          )}
+                          <Button variant="outline" size="icon" onClick={() => openEdit(vm)}>
+                            <Pencil className="h-4 w-4" />
+                          </Button>
+                          <Button variant="destructive" size="icon" onClick={() => handleDelete(vm.name)}>
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))
+                )}
               </tbody>
             </table>
           </CardContent>


### PR DESCRIPTION
## Summary
- show placeholder rows when VM list is empty
- show placeholder rows when ISO and image lists are empty

## Testing
- `npm install` *(fails: 404 fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68853d38fc288328a2f6a2922e58aaca