### PR TITLE
Expose ZFS pools and drop drive health

### DIFF
--- a/upservx-service/main.py
+++ b/upservx-service/main.py
@@ -139,7 +139,6 @@ class DriveInfo(BaseModel):
     filesystem: str
     mountpoint: str
     mounted: bool
-    health: str = "good"
     temperature: int | None = None
 
 
@@ -1752,7 +1751,7 @@ class ZFSPoolCreateRequest(BaseModel):
 
 @app.get("/drives/zfs")
 def list_zfs_pools():
-    return get_zfs_pools()
+    return {"pools": [p.dict() for p in get_zfs_pools()]}
 
 @app.get("/drives/zfs-debug")
 def zfs_debug():

--- a/upservx-service/main.py
+++ b/upservx-service/main.py
@@ -882,7 +882,13 @@ def get_zfs_pools() -> List[ZFSPoolInfo]:
             in_config = True
         elif pool and in_config:
             stripped = line.strip()
-            if not stripped or stripped.startswith("NAME"):
+            if not stripped:
+                in_config = False
+                continue
+            if stripped.startswith("NAME"):
+                continue
+            if stripped.startswith("errors:"):
+                in_config = False
                 continue
             parts = stripped.split()
             token = parts[0]
@@ -896,8 +902,6 @@ def get_zfs_pools() -> List[ZFSPoolInfo]:
             if not token.startswith("/"):
                 device = f"/dev/{token}"
             pool["devices"].append({"path": device, "status": state})
-        if pool and line.startswith("errors:"):
-            pass
     if pool:
         pools.append(ZFSPoolInfo(**pool))
     return pools

--- a/upservx-service/main.py
+++ b/upservx-service/main.py
@@ -139,6 +139,7 @@ class DriveInfo(BaseModel):
     filesystem: str
     mountpoint: str
     mounted: bool
+    health: str = "good"
     temperature: int | None = None
 
 

--- a/upservx/components/storage-management.tsx
+++ b/upservx/components/storage-management.tsx
@@ -12,7 +12,6 @@ interface Drive {
   filesystem: string
   mountpoint: string
   mounted: boolean
-  health: string
   temperature?: number | null
 }
 
@@ -181,19 +180,6 @@ export function StorageManagement() {
     }
   }
 
-  const getHealthColor = (health: string) => {
-    switch (health) {
-      case "good":
-        return "default"
-      case "warning":
-        return "outline"
-      case "critical":
-        return "destructive"
-      default:
-        return "secondary"
-    }
-  }
-
   const getUsagePercentage = (used: number, size: number) => {
     return Math.round((used / size) * 100)
   }
@@ -308,9 +294,6 @@ export function StorageManagement() {
                       <div className="text-sm text-muted-foreground">{drive.device}</div>
                     </div>
                     <Badge variant="outline">{drive.type}</Badge>
-                    <Badge variant={getHealthColor(drive.health)}>
-                      {drive.health === "good" ? "Good" : drive.health === "warning" ? "Warning" : "Critical"}
-                    </Badge>
                     {!drive.mounted && <Badge variant="destructive">Not mounted</Badge>}
                   </div>
                   <div className="flex items-center gap-2">

--- a/upservx/components/storage-management.tsx
+++ b/upservx/components/storage-management.tsx
@@ -15,10 +15,15 @@ interface Drive {
   temperature?: number | null
 }
 
+interface ZFSDevice {
+  path: string
+  status: string
+}
+
 interface ZFSPool {
   name: string
   type: string
-  devices: string[]
+  devices: ZFSDevice[]
 }
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
@@ -267,7 +272,16 @@ export function StorageManagement() {
                     <Badge variant="outline">{p.type}</Badge>
                   </div>
                   <div className="text-sm text-muted-foreground">
-                    Devices: {p.devices.join(', ')}
+                    Devices:{" "}
+                    {p.devices.map((d, i) => (
+                      <span
+                        key={d.path}
+                        className={d.status !== "ONLINE" ? "text-red-500" : ""}
+                      >
+                        {i > 0 && ", "}
+                        {d.path}
+                      </span>
+                    ))}
                   </div>
                 </div>
               ))}

--- a/upservx/components/storage-management.tsx
+++ b/upservx/components/storage-management.tsx
@@ -12,6 +12,7 @@ interface Drive {
   filesystem: string
   mountpoint: string
   mounted: boolean
+  health: string
   temperature?: number | null
 }
 
@@ -185,6 +186,19 @@ export function StorageManagement() {
     }
   }
 
+  const getHealthColor = (health: string) => {
+    switch (health) {
+      case "good":
+        return "default"
+      case "warning":
+        return "outline"
+      case "critical":
+        return "destructive"
+      default:
+        return "secondary"
+    }
+  }
+
   const getUsagePercentage = (used: number, size: number) => {
     return Math.round((used / size) * 100)
   }
@@ -308,6 +322,13 @@ export function StorageManagement() {
                       <div className="text-sm text-muted-foreground">{drive.device}</div>
                     </div>
                     <Badge variant="outline">{drive.type}</Badge>
+                    <Badge variant={getHealthColor(drive.health)}>
+                      {drive.health === "good"
+                        ? "Good"
+                        : drive.health === "warning"
+                        ? "Warning"
+                        : "Critical"}
+                    </Badge>
                     {!drive.mounted && <Badge variant="destructive">Not mounted</Badge>}
                   </div>
                   <div className="flex items-center gap-2">

--- a/upservx/components/system-overview.tsx
+++ b/upservx/components/system-overview.tsx
@@ -36,6 +36,7 @@ export function SystemOverview() {
     filesystem: string
     mountpoint: string
     mounted: boolean
+    health: string
     temperature?: number | null
   }
 

--- a/upservx/components/system-overview.tsx
+++ b/upservx/components/system-overview.tsx
@@ -36,7 +36,6 @@ export function SystemOverview() {
     filesystem: string
     mountpoint: string
     mounted: boolean
-    health: string
     temperature?: number | null
   }
 

--- a/upservx/package-lock.json
+++ b/upservx/package-lock.json
@@ -17,6 +17,7 @@
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-switch": "^1.2.5",
         "@radix-ui/react-tabs": "^1.1.12",
+        "@xterm/xterm": "^5.5.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.525.0",
@@ -24,8 +25,7 @@
         "next-themes": "^0.4.6",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "tailwind-merge": "^3.3.1",
-        "@xterm/xterm": "^5.3.0"
+        "tailwind-merge": "^3.3.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -2691,6 +2691,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
+      "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
+      "license": "MIT"
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -7146,12 +7152,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/@xterm/xterm": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.3.0.tgz",
-      "integrity": "sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==",
-      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "5.0.0",

--- a/upservx/package.json
+++ b/upservx/package.json
@@ -26,7 +26,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tailwind-merge": "^3.3.1",
-    "@xterm/xterm": "^5.3.0"
+    "@xterm/xterm": "^5.5.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Summary
- return ZFS pools from `/drives/zfs` and show them in storage management
- remove disk health field and badge from API and UI

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm install` *(fails: 404 Not Found - @xterm/xterm@5.3.0)*
- `python -m py_compile upservx-service/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6890e8b450648328a7be364e9c6fcb10