### PR TITLE
feat: add API key authentication

### DIFF
--- a/upservx/components/settings.tsx
+++ b/upservx/components/settings.tsx
@@ -14,6 +14,7 @@ export function Settings() {
     auto_updates: boolean
     monitoring: boolean
     ssh_port: number
+    api_key?: string
   }
 
   const [settings, setSettings] = useState<SettingsData>({
@@ -22,6 +23,7 @@ export function Settings() {
     auto_updates: false,
     monitoring: false,
     ssh_port: 22,
+    api_key: "",
   })
   const [message, setMessage] = useState<string | null>(null)
 
@@ -36,6 +38,7 @@ export function Settings() {
           auto_updates: data.auto_updates,
           monitoring: data.monitoring,
           ssh_port: data.ssh_port,
+          api_key: data.api_key || "",
         })
       }
     } catch (e) {
@@ -61,6 +64,19 @@ export function Settings() {
         body: JSON.stringify(settings),
       })
       if (res.ok) setMessage("Saved")
+    } catch (e) {
+      console.error(e)
+    }
+  }
+
+  const handleGenerateKey = async () => {
+    try {
+      const res = await fetch(apiUrl("/settings/api-key"), { method: "POST" })
+      if (res.ok) {
+        const data = await res.json()
+        setSettings({ ...settings, api_key: data.api_key })
+        setMessage("API key generated")
+      }
     } catch (e) {
       console.error(e)
     }
@@ -136,6 +152,13 @@ export function Settings() {
               onCheckedChange={(v) => setSettings({ ...settings, monitoring: v })}
             />
             <Label htmlFor="monitoring">Enable system monitoring</Label>
+          </div>
+          <div className="space-y-2 pt-4">
+            <Label htmlFor="api-key">API Key</Label>
+            <div className="flex space-x-2">
+              <Input id="api-key" value={settings.api_key} readOnly />
+              <Button onClick={handleGenerateKey}>Generate</Button>
+            </div>
           </div>
         </CardContent>
       </Card>

--- a/upservx/components/sidebar.tsx
+++ b/upservx/components/sidebar.tsx
@@ -12,6 +12,7 @@ import {
   Users,
   Disc,
   FileText,
+  Settings,
 } from "lucide-react"
 import { useEffect, useState } from "react"
 import { apiUrl } from "@/lib/api"
@@ -61,6 +62,7 @@ export function Sidebar({ activeSection, onSectionChange }: SidebarProps) {
     {
       title: "Administration",
       items: [
+        { id: "settings", label: "Settings", icon: Settings },
         { id: "users", label: "Users", icon: Users },
         { id: "backup", label: "Backup", icon: Shield },
         { id: "network", label: "Network", icon: Network },


### PR DESCRIPTION
## Summary
- allow API key Bearer auth and generation
- expose API key generation in settings UI

## Testing
- `pytest`
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891168d4bc88328a7ee5232e4d9ffb8