### PR TITLE
feat: add container security CVE scanning with expandable per-container details

### DIFF
--- a/upservx-service/api/security.py
+++ b/upservx-service/api/security.py
@@ -20,6 +20,7 @@ from handlers.security import (
     get_certificates,
     get_open_ports,
     scan_cves,
+    scan_container_cves,
 )
 
 router = APIRouter(prefix="/security", tags=["security"])
@@ -135,5 +136,17 @@ async def scan_cve_vulnerabilities(
     """Scan installed packages for CVEs via OSV.dev (Debian/Ubuntu only)."""
     try:
         return scan_cves(limit=limit)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/container-cve")
+async def scan_container_cve_vulnerabilities(
+    container_limit: int = Query(default=30, ge=1, le=100, description="Max Docker/LXC containers to scan"),
+    package_limit: int = Query(default=200, ge=20, le=1000, description="Max packages per container"),
+) -> Dict[str, Any]:
+    """Scan running Docker and LXC containers for CVEs via OSV.dev."""
+    try:
+        return scan_container_cves(container_limit=container_limit, package_limit=package_limit)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/upservx-service/handlers/security.py
+++ b/upservx-service/handlers/security.py
@@ -418,7 +418,9 @@ def _parse_os_release(content: str) -> Dict[str, str]:
 def _normalize_ecosystem(os_release: Dict[str, str]) -> Optional[str]:
     """Map container os-release fields to an OSV ecosystem string."""
     os_id = os_release.get("ID", "").lower()
+    os_id_like = os_release.get("ID_LIKE", "").lower()
     os_name = os_release.get("NAME", "").lower()
+    os_pretty = os_release.get("PRETTY_NAME", "").lower()
     version_id = os_release.get("VERSION_ID", "")
 
     if os_id == "ubuntu" or "ubuntu" in os_name:
@@ -431,6 +433,31 @@ def _normalize_ecosystem(os_release: Dict[str, str]) -> Optional[str]:
     if os_id == "alpine" or "alpine" in os_name:
         major_minor = ".".join(version_id.split(".")[:2]) if version_id else "3.20"
         return f"Alpine:v{major_minor}"
+
+    if os_id == "fedora" or "fedora" in os_name or "fedora" in os_id_like:
+        return f"Fedora:{version_id}" if version_id else "Fedora:40"
+
+    if (
+        os_id in {"rhel", "redhat", "red hat enterprise linux"}
+        or "rhel" in os_id_like
+        or "red hat" in os_name
+        or "red hat" in os_pretty
+    ):
+        major = version_id.split(".")[0] if version_id else "9"
+        return f"Red Hat:{major}"
+
+    if os_id == "centos" or "centos" in os_name or "centos" in os_pretty:
+        major = version_id.split(".")[0] if version_id else "9"
+        # OSV nutzt kein eigenes CentOS-Ecosystem; CentOS wird auf Red Hat gemappt.
+        return f"Red Hat:{major}"
+
+    if (
+        os_id in {"opensuse", "opensuse-leap", "opensuse-tumbleweed", "sles", "suse"}
+        or "suse" in os_name
+        or "suse" in os_pretty
+        or "suse" in os_id_like
+    ):
+        return f"openSUSE:{version_id}" if version_id else "openSUSE:15.6"
 
     return None
 

--- a/upservx-service/handlers/security.py
+++ b/upservx-service/handlers/security.py
@@ -434,6 +434,19 @@ def _normalize_ecosystem(os_release: Dict[str, str]) -> Optional[str]:
         major_minor = ".".join(version_id.split(".")[:2]) if version_id else "3.20"
         return f"Alpine:v{major_minor}"
 
+    if (
+        os_id in {"arch", "archlinux", "manjaro", "artix", "endeavouros", "garuda"}
+        or "arch" in os_id_like
+        or "arch" in os_name
+        or "arch" in os_pretty
+        or "manjaro" in os_name
+        or "manjaro" in os_pretty
+        or "artix" in os_name
+        or "artix" in os_pretty
+    ):
+        # Arch-Derivate werden auf das OSV-Ecosystem fuer Arch Linux gemappt.
+        return "Arch Linux"
+
     if os_id == "fedora" or "fedora" in os_name or "fedora" in os_id_like:
         return f"Fedora:{version_id}" if version_id else "Fedora:40"
 

--- a/upservx-service/handlers/security.py
+++ b/upservx-service/handlers/security.py
@@ -19,6 +19,8 @@ import urllib.error
 from datetime import datetime, timezone
 from typing import Dict, Any, List, Optional
 
+from handlers.containers import get_docker_containers, get_lxc_containers
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -400,6 +402,294 @@ def _get_dpkg_packages() -> List[Dict[str, str]]:
             ver = re.sub(r"^\d+:", "", parts[1])
             packages.append({"name": parts[0], "version": ver})
     return packages
+
+
+def _parse_os_release(content: str) -> Dict[str, str]:
+    """Parse /etc/os-release style key/value data."""
+    data: Dict[str, str] = {}
+    for line in content.splitlines():
+        if "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        data[k.strip()] = v.strip().strip('"')
+    return data
+
+
+def _normalize_ecosystem(os_release: Dict[str, str]) -> Optional[str]:
+    """Map container os-release fields to an OSV ecosystem string."""
+    os_id = os_release.get("ID", "").lower()
+    os_name = os_release.get("NAME", "").lower()
+    version_id = os_release.get("VERSION_ID", "")
+
+    if os_id == "ubuntu" or "ubuntu" in os_name:
+        return f"Ubuntu:{version_id}" if version_id else "Ubuntu:24.04"
+
+    if os_id == "debian" or "debian" in os_name:
+        major = version_id.split(".")[0] if version_id else "12"
+        return f"Debian:{major}"
+
+    if os_id == "alpine" or "alpine" in os_name:
+        major_minor = ".".join(version_id.split(".")[:2]) if version_id else "3.20"
+        return f"Alpine:v{major_minor}"
+
+    return None
+
+
+def _run_in_container(container_type: str, name: str, inner_cmd: List[str], timeout: int = 20) -> tuple[str, str, int]:
+    """Execute a command in a Docker or LXC container and return (stdout, stderr, rc)."""
+    if container_type == "docker":
+        cmd = ["docker", "exec", name, *inner_cmd]
+    elif container_type == "lxc":
+        cmd = ["lxc", "exec", name, "--", *inner_cmd]
+    else:
+        return "", f"Unsupported container type: {container_type}", 2
+    return _run(cmd, timeout=timeout)
+
+
+def _get_container_os_release(container_type: str, name: str) -> Optional[Dict[str, str]]:
+    """Read os-release from a container to identify ecosystem for CVE lookups."""
+    stdout, _, rc = _run_in_container(container_type, name, ["cat", "/etc/os-release"], timeout=10)
+    if rc != 0 or not stdout.strip():
+        return None
+    return _parse_os_release(stdout)
+
+
+def _get_container_packages(container_type: str, name: str, package_limit: int = 200) -> tuple[List[Dict[str, str]], Optional[str]]:
+    """
+    Return installed package list from a container plus optional detected ecosystem.
+    Supports dpkg, apk and rpm based containers.
+    """
+    os_release = _get_container_os_release(container_type, name) or {}
+    ecosystem = _normalize_ecosystem(os_release)
+
+    stdout, _, rc = _run_in_container(
+        container_type,
+        name,
+        ["dpkg-query", "-W", "-f=${Package}\\t${Version}\\n"],
+        timeout=25,
+    )
+    if rc == 0 and stdout.strip():
+        packages: List[Dict[str, str]] = []
+        for line in stdout.splitlines():
+            parts = line.strip().split("\t")
+            if len(parts) >= 2 and parts[0] and parts[1] and parts[1] not in ("<none>", "-"):
+                ver = re.sub(r"^\d+:", "", parts[1])
+                packages.append({"name": parts[0], "version": ver})
+        return packages[:package_limit], ecosystem
+
+    stdout, _, rc = _run_in_container(container_type, name, ["apk", "info", "-v"], timeout=25)
+    if rc == 0 and stdout.strip():
+        packages = []
+        for line in stdout.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            idx = line.rfind("-")
+            if idx <= 0:
+                continue
+            name_part = line[:idx]
+            version = line[idx + 1 :]
+            if name_part and version:
+                packages.append({"name": name_part, "version": version})
+        return packages[:package_limit], ecosystem or "Alpine:v3.20"
+
+    stdout, _, rc = _run_in_container(
+        container_type,
+        name,
+        ["rpm", "-qa", "--qf", "%{NAME}\\t%{VERSION}-%{RELEASE}\\n"],
+        timeout=25,
+    )
+    if rc == 0 and stdout.strip():
+        packages = []
+        for line in stdout.splitlines():
+            parts = line.strip().split("\t")
+            if len(parts) >= 2 and parts[0] and parts[1]:
+                packages.append({"name": parts[0], "version": parts[1]})
+        return packages[:package_limit], ecosystem
+
+    return [], ecosystem
+
+
+def _scan_osv_packages(packages: List[Dict[str, str]], ecosystem: str) -> List[Dict[str, Any]]:
+    """Query OSV.dev for a package list and return normalized vulnerabilities."""
+    all_vulns: List[Dict[str, Any]] = []
+
+    for i in range(0, len(packages), 100):
+        batch = packages[i : i + 100]
+        queries = [
+            {
+                "version": pkg["version"],
+                "package": {"name": pkg["name"], "ecosystem": ecosystem},
+            }
+            for pkg in batch
+        ]
+        payload = json.dumps({"queries": queries}).encode()
+        req = urllib.request.Request(
+            _OSV_BATCH_URL,
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                result = json.loads(resp.read())
+        except Exception:
+            continue
+
+        for j, res in enumerate(result.get("results", [])):
+            for vuln in res.get("vulns", []):
+                pkg = batch[j]
+                severity = "unknown"
+                score: Optional[float] = None
+
+                for sev in vuln.get("severity", []):
+                    if sev.get("type") in ("CVSS_V3", "CVSS_V4"):
+                        try:
+                            score = float(sev["score"])
+                            if score >= 9.0:
+                                severity = "critical"
+                            elif score >= 7.0:
+                                severity = "high"
+                            elif score >= 4.0:
+                                severity = "medium"
+                            else:
+                                severity = "low"
+                        except (ValueError, KeyError):
+                            pass
+                        break
+                    elif sev.get("type") == "CVSS_V2" and score is None:
+                        try:
+                            score = float(sev["score"])
+                            severity = "high" if score >= 7.0 else ("medium" if score >= 4.0 else "low")
+                        except (ValueError, KeyError):
+                            pass
+
+                aliases = [a for a in vuln.get("aliases", []) if a.startswith("CVE-")]
+                cve_id = aliases[0] if aliases else vuln.get("id", "")
+
+                all_vulns.append(
+                    {
+                        "package": pkg["name"],
+                        "version": pkg["version"],
+                        "vuln_id": vuln.get("id", ""),
+                        "cve_id": cve_id,
+                        "summary": vuln.get("summary", ""),
+                        "severity": severity,
+                        "cvss_score": score,
+                        "published": (vuln.get("published", "") or "")[:10],
+                    }
+                )
+
+    all_vulns.sort(key=lambda v: (_SEV_ORDER.get(v["severity"], 4), -(v["cvss_score"] or 0)))
+    return all_vulns
+
+
+def scan_container_cves(container_limit: int = 30, package_limit: int = 200) -> Dict[str, Any]:
+    """Scan Docker and LXC containers for known CVEs using OSV.dev."""
+    docker = [c for c in get_docker_containers() if c.name]
+    lxc = [c for c in get_lxc_containers() if c.name]
+
+    targets = [
+        {"name": c.name, "type": "docker", "status": c.status}
+        for c in docker
+    ] + [
+        {"name": c.name, "type": "lxc", "status": c.status}
+        for c in lxc
+    ]
+
+    targets = targets[:container_limit]
+
+    severity_totals: Dict[str, int] = {"critical": 0, "high": 0, "medium": 0, "low": 0, "unknown": 0}
+    scanned = 0
+    results: List[Dict[str, Any]] = []
+
+    for target in targets:
+        name = target["name"]
+        container_type = target["type"]
+        status = str(target.get("status", "")).lower()
+
+        # Non-running containers usually can't be inspected via exec.
+        if status not in ("running", "up"):
+            results.append(
+                {
+                    "name": name,
+                    "type": container_type,
+                    "status": target.get("status", "unknown"),
+                    "available": False,
+                    "reason": "Container is not running",
+                    "packages_scanned": 0,
+                    "total_vulns": 0,
+                    "severity_counts": {"critical": 0, "high": 0, "medium": 0, "low": 0, "unknown": 0},
+                    "vulnerabilities": [],
+                }
+            )
+            continue
+
+        packages, ecosystem = _get_container_packages(container_type, name, package_limit=package_limit)
+        if not packages:
+            results.append(
+                {
+                    "name": name,
+                    "type": container_type,
+                    "status": target.get("status", "unknown"),
+                    "available": False,
+                    "reason": "Could not read package inventory inside container",
+                    "packages_scanned": 0,
+                    "total_vulns": 0,
+                    "severity_counts": {"critical": 0, "high": 0, "medium": 0, "low": 0, "unknown": 0},
+                    "vulnerabilities": [],
+                }
+            )
+            continue
+
+        if not ecosystem:
+            results.append(
+                {
+                    "name": name,
+                    "type": container_type,
+                    "status": target.get("status", "unknown"),
+                    "available": False,
+                    "reason": "Unsupported container OS for OSV scan",
+                    "packages_scanned": len(packages),
+                    "total_vulns": 0,
+                    "severity_counts": {"critical": 0, "high": 0, "medium": 0, "low": 0, "unknown": 0},
+                    "vulnerabilities": [],
+                }
+            )
+            continue
+
+        vulns = _scan_osv_packages(packages, ecosystem)
+        counts: Dict[str, int] = {"critical": 0, "high": 0, "medium": 0, "low": 0, "unknown": 0}
+        for vuln in vulns:
+            sev = vuln.get("severity", "unknown")
+            counts[sev] = counts.get(sev, 0) + 1
+            severity_totals[sev] = severity_totals.get(sev, 0) + 1
+
+        scanned += 1
+        results.append(
+            {
+                "name": name,
+                "type": container_type,
+                "status": target.get("status", "unknown"),
+                "available": True,
+                "ecosystem": ecosystem,
+                "packages_scanned": len(packages),
+                "total_vulns": len(vulns),
+                "severity_counts": counts,
+                "vulnerabilities": vulns,
+            }
+        )
+
+    return {
+        "available": True,
+        "containers_total": len(targets),
+        "containers_scanned": scanned,
+        "containers_with_issues": sum(1 for r in results if r.get("available") and r.get("total_vulns", 0) > 0),
+        "severity_counts": severity_totals,
+        "total_vulns": sum(r.get("total_vulns", 0) for r in results),
+        "containers": results,
+    }
 
 
 def scan_cves(limit: int = 300) -> Dict[str, Any]:

--- a/upservx-service/handlers/security.py
+++ b/upservx-service/handlers/security.py
@@ -533,6 +533,15 @@ def _get_container_packages(container_type: str, name: str, package_limit: int =
                 packages.append({"name": name_part, "version": version})
         return packages[:package_limit], ecosystem or "Alpine:v3.20"
 
+    stdout, _, rc = _run_in_container(container_type, name, ["pacman", "-Q"], timeout=25)
+    if rc == 0 and stdout.strip():
+        packages = []
+        for line in stdout.splitlines():
+            parts = line.strip().split()
+            if len(parts) >= 2 and parts[0] and parts[1]:
+                packages.append({"name": parts[0], "version": parts[1]})
+        return packages[:package_limit], ecosystem or "Arch Linux"
+
     stdout, _, rc = _run_in_container(
         container_type,
         name,

--- a/upservx/components/security.tsx
+++ b/upservx/components/security.tsx
@@ -120,6 +120,42 @@ interface CveData {
   vulnerabilities?: CveVuln[]
 }
 
+interface ContainerCveResult {
+  name: string
+  type: string
+  status: string
+  available: boolean
+  reason?: string
+  ecosystem?: string
+  packages_scanned: number
+  total_vulns: number
+  severity_counts: {
+    critical: number
+    high: number
+    medium: number
+    low: number
+    unknown: number
+  }
+  vulnerabilities: CveVuln[]
+}
+
+interface ContainerCveData {
+  available: boolean
+  error?: string
+  containers_total: number
+  containers_scanned: number
+  containers_with_issues: number
+  total_vulns: number
+  severity_counts: {
+    critical: number
+    high: number
+    medium: number
+    low: number
+    unknown: number
+  }
+  containers: ContainerCveResult[]
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -191,6 +227,10 @@ export default function SecurityManagement() {
   const [cveData, setCveData] = useState<CveData | null>(null)
   const [loadingCve, setLoadingCve] = useState(false)
   const [cveFilter, setCveFilter] = useState<"all" | "critical" | "high" | "medium" | "low">("all")
+  const [loadingContainerCve, setLoadingContainerCve] = useState(false)
+  const [containerCveData, setContainerCveData] = useState<ContainerCveData | null>(null)
+  const [containerCveFilter, setContainerCveFilter] = useState<"all" | "critical" | "high" | "medium" | "low">("all")
+  const [expandedContainerKey, setExpandedContainerKey] = useState<string | null>(null)
   const [portProtoFilter, setPortProtoFilter] = useState<"all" | "tcp" | "udp">("all")
   const [portAddrFilter, setPortAddrFilter] = useState<"all" | "public" | "loopback">("all")
   const [certStatusFilter, setCertStatusFilter] = useState<"all" | "expired" | "expiring" | "valid">("all")
@@ -271,6 +311,30 @@ export default function SecurityManagement() {
       setCveData({ available: false, error: "Failed to reach the CVE scanner" })
     } finally {
       setLoadingCve(false)
+    }
+  }, [])
+
+  const fetchContainerCves = useCallback(async () => {
+    setLoadingContainerCve(true)
+    try {
+      const res = await fetch(apiUrl("/security/container-cve"), { credentials: "include" })
+      const data = await res.json()
+      setContainerCveData(data)
+      setExpandedContainerKey(null)
+    } catch {
+      setContainerCveData({
+        available: false,
+        error: "Failed to reach container CVE scanner",
+        containers_total: 0,
+        containers_scanned: 0,
+        containers_with_issues: 0,
+        total_vulns: 0,
+        severity_counts: { critical: 0, high: 0, medium: 0, low: 0, unknown: 0 },
+        containers: [],
+      })
+      setExpandedContainerKey(null)
+    } finally {
+      setLoadingContainerCve(false)
     }
   }, [])
 
@@ -446,7 +510,7 @@ export default function SecurityManagement() {
 
       {/* Tabs */}
       <Tabs defaultValue="fail2ban">
-        <TabsList className="grid w-full grid-cols-5">
+        <TabsList className="grid w-full grid-cols-6">
           <TabsTrigger value="fail2ban" className="flex items-center gap-2">
             <Ban className="h-4 w-4" /> Fail2Ban
           </TabsTrigger>
@@ -458,6 +522,9 @@ export default function SecurityManagement() {
           </TabsTrigger>
           <TabsTrigger value="ports" className="flex items-center gap-2">
             <Network className="h-4 w-4" /> Open Ports
+          </TabsTrigger>
+          <TabsTrigger value="container-security" className="flex items-center gap-2">
+            <ShieldAlert className="h-4 w-4" /> Container Security
           </TabsTrigger>
           <TabsTrigger value="cve" className="flex items-center gap-2">
             <Bug className="h-4 w-4" /> CVE Scan
@@ -913,6 +980,155 @@ export default function SecurityManagement() {
                 </Table>
               </CardContent>
             </Card>
+          )}
+        </TabsContent>
+
+        {/* ---------------------------------------------------------------- */}
+        {/* CVE Scanner Tab                                                    */}
+        {/* ---------------------------------------------------------------- */}
+        <TabsContent value="container-security" className="space-y-4 mt-4">
+          <div className="flex justify-between items-center">
+            <div className="flex items-center gap-3">
+              <h2 className="text-lg font-semibold">Container Security</h2>
+              {containerCveData?.available && (
+                <>
+                  <Badge variant="outline">{containerCveData.containers_scanned}/{containerCveData.containers_total} scanned</Badge>
+                  <Badge variant="outline">{containerCveData.containers_with_issues} affected</Badge>
+                </>
+              )}
+            </div>
+            <div className="flex gap-2">
+              {containerCveData?.available && (
+                <>
+                  {(["all", "critical", "high", "medium", "low"] as const).map((f) => (
+                    <Button
+                      key={f}
+                      variant={containerCveFilter === f ? "default" : "outline"}
+                      size="sm"
+                      onClick={() => setContainerCveFilter(f)}
+                    >
+                      {f === "all" ? "All" : f.charAt(0).toUpperCase() + f.slice(1)}
+                    </Button>
+                  ))}
+                </>
+              )}
+              <Button
+                variant={containerCveData === null ? "default" : "outline"}
+                size="sm"
+                onClick={fetchContainerCves}
+                disabled={loadingContainerCve}
+              >
+                {loadingContainerCve ? (
+                  <RefreshCw className="h-4 w-4 mr-2 animate-spin" />
+                ) : (
+                  <Search className="h-4 w-4 mr-2" />
+                )}
+                {containerCveData === null ? "Start Scan" : "Re-Scan"}
+              </Button>
+            </div>
+          </div>
+
+          {containerCveData === null && !loadingContainerCve ? (
+            <Card>
+              <CardContent className="pt-10 pb-10 text-center text-muted-foreground space-y-3">
+                <ShieldAlert className="mx-auto h-10 w-10 text-muted-foreground/40" />
+                <p className="font-medium">Container CVE scan not started yet</p>
+                <p className="text-xs">
+                  Scans running Docker and LXC containers for known CVEs via <span className="font-mono">osv.dev</span>.
+                </p>
+              </CardContent>
+            </Card>
+          ) : loadingContainerCve ? (
+            <Card>
+              <CardContent className="pt-10 pb-10 text-center text-muted-foreground space-y-3">
+                <RefreshCw className="mx-auto h-8 w-8 animate-spin" />
+                <p>Scanning container packages against OSV.dev… this may take a while.</p>
+              </CardContent>
+            </Card>
+          ) : containerCveData?.available === false ? (
+            <Card>
+              <CardContent className="pt-6 text-center text-muted-foreground">
+                <AlertTriangle className="mx-auto h-8 w-8 mb-2 text-yellow-500" />
+                <p>Container CVE scan is not available.</p>
+                <p className="text-xs mt-1">{containerCveData.error}</p>
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="space-y-4">
+              {(containerCveData?.containers ?? []).map((container) => {
+                const containerKey = `${container.type}:${container.name}`
+                const isExpanded = expandedContainerKey === containerKey
+                const filteredVulns = (container.vulnerabilities ?? []).filter(
+                  (v) => containerCveFilter === "all" || v.severity === containerCveFilter
+                )
+
+                return (
+                  <Card key={containerKey}>
+                    <CardHeader
+                      className="pb-3 cursor-pointer"
+                      onClick={() => setExpandedContainerKey(isExpanded ? null : containerKey)}
+                    >
+                      <div className="flex items-center justify-between gap-2 flex-wrap">
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <CardTitle className="text-base font-medium">{container.name}</CardTitle>
+                          <Badge variant="outline" className="uppercase">{container.type}</Badge>
+                          <Badge variant={container.status.toLowerCase() === "running" || container.status.toLowerCase() === "up" ? "default" : "secondary"}>
+                            {container.status}
+                          </Badge>
+                          {container.ecosystem && <Badge variant="outline">{container.ecosystem}</Badge>}
+                        </div>
+                        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                          <span>{container.packages_scanned} packages</span>
+                          <span className="border-l border-border pl-2">
+                            CVEs: <span className={container.total_vulns > 0 ? "text-red-400 font-semibold" : "text-green-400 font-semibold"}>{container.total_vulns}</span>
+                          </span>
+                          <span className="border-l border-border pl-2 font-medium text-foreground/80">
+                            {isExpanded ? "Hide CVEs" : "Show CVEs"}
+                          </span>
+                        </div>
+                      </div>
+                    </CardHeader>
+
+                    {isExpanded && (
+                    <CardContent>
+                      {!container.available ? (
+                        <p className="text-sm text-muted-foreground">{container.reason || "Container scan unavailable"}</p>
+                      ) : filteredVulns.length === 0 ? (
+                        <p className="text-sm text-green-500">No CVEs found for selected filter.</p>
+                      ) : (
+                        <Table>
+                          <TableHeader>
+                            <TableRow>
+                              <TableHead>Severity</TableHead>
+                              <TableHead>CVE</TableHead>
+                              <TableHead>Package</TableHead>
+                              <TableHead>Version</TableHead>
+                              <TableHead>Summary</TableHead>
+                            </TableRow>
+                          </TableHeader>
+                          <TableBody>
+                            {filteredVulns.slice(0, 80).map((v, i) => (
+                              <TableRow key={i}>
+                                <TableCell>
+                                  <SeverityBadge severity={v.severity} score={v.cvss_score} />
+                                </TableCell>
+                                <TableCell className="font-mono text-xs font-medium">{v.cve_id || v.vuln_id}</TableCell>
+                                <TableCell className="font-mono text-sm">{v.package}</TableCell>
+                                <TableCell className="font-mono text-xs text-muted-foreground">{v.version}</TableCell>
+                                <TableCell className="text-xs text-muted-foreground max-w-80 truncate" title={v.summary}>
+                                  {v.summary || "—"}
+                                </TableCell>
+                              </TableRow>
+                            ))}
+                          </TableBody>
+                        </Table>
+                      )}
+                    </CardContent>
+                    )}
+                  </Card>
+                )
+              })}
+            </div>
           )}
         </TabsContent>
 


### PR DESCRIPTION
## Summary
This PR adds CVE scanning for available Docker and LXC containers in the Security module and introduces a dedicated Container Security tab workflow.

## What Changed

### Backend
- Added new endpoint:
  - GET /security/container-cve
- Implemented container CVE scan logic:
  - Detects available Docker and LXC containers
  - Scans running containers
  - Collects installed packages from inside containers
  - Queries OSV in batches and aggregates CVEs per container
- Added package manager support inside containers:
  - dpkg-query
  - apk
  - pacman
  - rpm
- Extended distro/ecosystem mapping for container OS detection:
  - Ubuntu, Debian, Alpine
  - Fedora
  - RHEL
  - CentOS
  - openSUSE / SUSE / SLES
  - Arch Linux and derivatives (Manjaro, Artix, EndeavourOS, Garuda)

### Frontend
- Added new Security tab:
  - Container Security
- Added scan controls:
  - Start Scan / Re-Scan
  - Severity filter
- Changed result UX to accordion-like behavior:
  - Initially only container rows are shown
  - CVEs are shown only after clicking a container
  - Only one container can be expanded at a time

## Why
This enables vulnerability visibility at container level instead of only host-level package scans, and improves usability with a focused, one-container-at-a-time details view.

## Testing
- Verified editor diagnostics for changed files show no TypeScript/Python analysis errors.
- Manually reviewed the new endpoint and UI flow for:
  - Loading states
  - Unavailable scan states
  - Empty vulnerability states
  - Single-expand behavior in Container Security

## Screenshots
- Added/updated screenshots can be attached for:
  - Container Security tab before scan
  - Scan results list
  - Expanded container CVE details

## Related
- No linked issue.

## PR Checklist
- [x] Code follows existing project style
- [x] Changes were tested manually
- [ ] Documentation updated (if required)
- [x] No unnecessary files included
- [x] PR description explains what changed and why
- [ ] Automated tests executed (if applicable)